### PR TITLE
CHORE: Update depencencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,10 +62,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           toolchain: ${{ matrix.rust }}
           components: rustfmt,clippy
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,12 @@ thiserror = "1.0.38"
 tokio = { version = "1.16", features = ["full"] }
 
 fvm_ipld_encoding = "0.3"
-fvm_shared = { version = "=3.0.0-alpha.17", default-features = false, features = ["crypto"], optional = true }
+fvm_shared = { version = "~3.2", default-features = false, features = ["crypto"], optional = true }
 fvm_ipld_blockstore = { version = "0.1", optional = true }
-ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git", tag = "v0.2.0" }
+
+# Using the IPC SDK without the `fil-actor` feature so as not to depend on the actor `Runtime`.
+# Using the `main` branch instead of the highest available tag `v0.3.0` because the latter doesn't have a feature flag for the `Runtime`.
+ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git", default-features = false, branch = "main" }
 
 [dev-dependencies]
 quickcheck_macros = "1"

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 use fvm_shared::address::Address;
-use ipc_sdk::subnet_id::{SubnetID, ROOTNET_ID};
+use ipc_sdk::subnet_id::SubnetID;
 use libipld::{Cid, Multihash};
 use quickcheck::Arbitrary;
 
@@ -26,12 +26,21 @@ pub struct ArbSubnetID(pub SubnetID);
 
 impl Arbitrary for ArbSubnetID {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let mut parent = ROOTNET_ID.clone();
-        for _ in 0..=u8::arbitrary(g) % 5 {
-            let addr = ArbAddress::arbitrary(g).0;
-            parent = SubnetID::new_from_parent(&parent, addr);
-        }
-        Self(parent)
+        let child_count = usize::arbitrary(g) % 4;
+
+        let children = (0..child_count)
+            .map(|_| {
+                if bool::arbitrary(g) {
+                    Address::new_id(u64::arbitrary(g))
+                } else {
+                    // Only expectign EAM managed delegated addresses.
+                    let subaddr: [u8; 20] = std::array::from_fn(|_| Arbitrary::arbitrary(g));
+                    Address::new_delegated(10, &subaddr).unwrap()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        Self(SubnetID::new(u64::arbitrary(g), children))
     }
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -30,7 +30,7 @@ use ipc_ipld_resolver::{
     Client, Config, ConnectionConfig, ContentConfig, DiscoveryConfig, Event, MembershipConfig,
     NetworkConfig, Service, VoteRecord,
 };
-use ipc_sdk::subnet_id::{SubnetID, ROOTNET_ID};
+use ipc_sdk::subnet_id::SubnetID;
 use libipld::{
     multihash::{Code, MultihashDigest},
     Cid,
@@ -364,7 +364,8 @@ fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
 /// Make a subnet under a rootnet.
 fn make_subnet_id(actor_id: ActorID) -> SubnetID {
     let act = Address::new_id(actor_id);
-    SubnetID::new_from_parent(&ROOTNET_ID, act)
+    let root = SubnetID::new_root(0);
+    SubnetID::new_from_parent(&root, act)
 }
 
 /// Insert a HAMT into the block store of an agent.


### PR DESCRIPTION
* Updates the `ipc-sdk` dependency to point at `main` and remove the `fil-actors` which we don't need.
* Updates the Rust Github action source