### PR TITLE
Migrate ipc-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ fvm_ipld_blockstore = { version = "0.1", optional = true }
 
 # Using the IPC SDK without the `fil-actor` feature so as not to depend on the actor `Runtime`.
 # Using the `main` branch instead of the highest available tag `v0.3.0` because the latter doesn't have a feature flag for the `Runtime`.
-ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git", default-features = false, branch = "main" }
+ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-agent.git", default-features = false, branch = "dev" }
 
 [dev-dependencies]
 quickcheck_macros = "1"

--- a/src/behaviour/content.rs
+++ b/src/behaviour/content.rs
@@ -317,7 +317,7 @@ fn select_non_ephemeral(mut addr: Multiaddr) -> Multiaddr {
         }
     }
     keep.reverse();
-    Multiaddr::from_iter(keep.into_iter())
+    Multiaddr::from_iter(keep)
 }
 
 #[cfg(test)]

--- a/src/provider_cache.rs
+++ b/src/provider_cache.rs
@@ -43,7 +43,7 @@ pub struct SubnetProviderCache {
 impl SubnetProviderCache {
     pub fn new(max_subnets: usize, static_subnets: Vec<SubnetID>) -> Self {
         Self {
-            pinned_subnets: HashSet::from_iter(static_subnets.into_iter()),
+            pinned_subnets: HashSet::from_iter(static_subnets),
             max_subnets,
             routable_peers: Default::default(),
             subnet_providers: Default::default(),


### PR DESCRIPTION
Changes:
- `ipc-sdk` is deprecated in `ipc-actor` crate and it was migrated to `ipc-agent`. 
- Updating the crate to `dev` as well. 
- Fix minor linting issue.